### PR TITLE
Bump coffeescript to v2 to allow async/await

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
           * Always delay requires, otherwise your plugin will cause trouble
           * with db-migrates performance and generates issues to your users.
           */
-        require('coffee-script').register();
+        require('coffeescript').register();
 
         /**
           * Return value of this hook can be both, pure value or a promise.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "db-migrate-plugin-coffee",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A db-migrate plugin to enable coffee script style migrations.",
   "main": "index.js",
   "dependencies": {
-    "coffee-script": "^1.11.0"
+    "coffeescript": "^2.2.4"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This lets you do things a little more concisely. eg:

```
exports.down = (db) ->
  await db.dropTable 'session'
  await db.dropTable 'log'
  await db.dropTable 'user'
```